### PR TITLE
fix: overwrite of argument values

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -90,7 +90,8 @@ def main():
     log = Logger.setup_logger(args.get('quiet') + args.get('debug'), args.get('log_file'))
     log.debug('Debug logging enabled.')
 
-    args_sanitized = args.get()
+    # debug only: output sanitized version of arguments
+    args_sanitized = args.get().copy()
     for key in ['client_id', 'client_secret', 'pushbullet_key']:
         if args_sanitized[key]:
             args_sanitized.update({key: 24 * '*' + args_sanitized[key][24:]})


### PR DESCRIPTION
Sanitize on a new copy of argument dictionary instead of  overwriting values in the original Argument class due to return-by-reference of Python in regards of dicts.

Currently value are independently sanitized in two places:
1. For debug logging for initial CLI args in __init__.py
2. For debug logging for finalize config in Configuration class
