### PR TITLE
perf: increase download chunk size

### DIFF
--- a/src/downloader.py
+++ b/src/downloader.py
@@ -127,7 +127,7 @@ class Downloader:
                         continue
 
                     # write downloaded chunks to temporary file
-                    for chunk in _r.iter_content(chunk_size=1024):
+                    for chunk in _r.iter_content(chunk_size=262144):
                         tmp_ts_file.write(chunk)
 
                     self.log.debug(f'Segment {Path(ts_path).stem} download completed.')


### PR DESCRIPTION
Greatly increase ts_segment download chunk size from 1024 (1 KiB) to 262144 (256 KiB) 

Performance profiling shows change reduced my CPU usage from 100% to 20% on a single CPU core while also increasing download speed by 10-15 times.

Most computers have more have 1 KiB of free memory available and segment sizes are within the range of megabytes.  
Small chunk sizes are not ideal for large downloads and are better suited for very small files ( < 50 KiB) or if the system has very very low memory available (less than 1 MiB free RAM).

A chunk size of 1024 and a segment size of 1 MiB will result in 1024 write syscalls to disk greatly increasing CPU usage and slowing down disk write speeds.

Modern HDD and SSD drives cannot write smaller than 4 KiB at a time and for certain filesystems with copy-on-write, these tiny 1 KiB writes drastically reduces CPU and download performance even more (>10x performance reduction).

OS/filesystem implementations help mitigate some of this performance loss via write buffers only to up to a certain point.