### PR TITLE
Update the help text regarding the lock file location

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ optional arguments:
   -L LOG_FILE, --log-file LOG_FILE
                         Output logs to specified file.
   -I CONFIG_DIR, --config-dir CONFIG_DIR
-                        Directory to store configuration, VOD database and lock files.
+                        Directory to store configuration and VOD database.
                         (default: $HOME/.config/twitch-archiver)
   -p PUSHBULLET_KEY, --pushbullet-key PUSHBULLET_KEY
                         Pushbullet key for sending pushes on error. Enabled by supplying key.

--- a/twitcharchiver/__init__.py
+++ b/twitcharchiver/__init__.py
@@ -119,7 +119,7 @@ def main():
     parser.add_argument('-L', '--log-file', action='store', help='Output logs to specified file.', type=Path,
                         default=getenv("TWITCH_ARCHIVER_LOG_FILE", False))
     parser.add_argument('-I', '--config-dir', action='store', type=Path,
-                        help='Directory to store configuration, VOD database and lock files.\n(default: %(default)s)',
+                        help='Directory to store configuration and VOD database.\n(default: %(default)s)',
                         default=getenv('TWITCH_ARCHIVER_CONFIG_DIR',
                                        Path(os.path.expanduser("~"), '.config', 'twitch-archiver')))
     parser.add_argument('-p', '--pushbullet-key', action='store',


### PR DESCRIPTION
They are no longer in the config directory as of commit 4f8f271afa1730db7b858c0e812d75ac636835bc.

The [Configuration Files](https://github.com/Brisppy/twitch-archiver/wiki/Wiki#configuration-files) section of the wiki also needs updating, although ideally the new location of the lock files (or just the temporary folder itself) should be mentioned there as well.